### PR TITLE
Take into account event.DOM_DELTA_XXX on scroll

### DIFF
--- a/src/controls/OrbitControls.js
+++ b/src/controls/OrbitControls.js
@@ -657,13 +657,27 @@ var OrbitControls = function ( object ) {
 
 	function handleMouseWheel( event ) {
 
-		if ( event.deltaY < 0 ) {
+    // deltaY isn't always reported in pixels, so do
+    // our best to normalize it somewhat. Unfortunately
+    // there is no exact way to do this, so rather try and
+    // aim for values that will match the user's expectation
+    // https://stackoverflow.com/questions/20110224/what-is-the-height-of-a-line-in-a-wheel-event-deltamode-dom-delta-line
+    var deltaY = event.deltaY;
+    if ( event.deltaMode === event.DOM_DELTA_LINE) { 
+      // Jump by a "line" (32px)
+      deltaY *= 32;
+    } else if ( event.deltaMode === event.DOM_DELTA_PAGE ) {
+      // Jump by a "page" (100px)
+      deltaY *= 100;
+    }
 
-			dollyIn( getZoomScale( event.deltaY ) );
+		if ( deltaY < 0 ) {
 
-		} else if ( event.deltaY > 0 ) {
+			dollyIn( getZoomScale( deltaY ) );
 
-			dollyOut( getZoomScale( event.deltaY ) );
+		} else if ( deltaY > 0 ) {
+
+			dollyOut( getZoomScale( deltaY ) );
 
 		}
 


### PR DESCRIPTION
Scroll event deltaY isn't always reported in pixels, so do our best to normalize.