### PR TITLE
bugfix: valid args for ImageLoader.load

### DIFF
--- a/src/datasources/base.js
+++ b/src/datasources/base.js
@@ -128,7 +128,9 @@ class BaseDatasource {
 
         this.updateIndirectionTexture();
         this.notifyUpdate();
-      }, () => {
+      },
+      () => { /* progress */ },
+      () => {
         console.error( 'Failed to get image', quadkey );
         delete this.fetching[ quadkey ];
       } );


### PR DESCRIPTION
ImageLoader.load has the following signature (see https://threejs.org/docs/#api/en/loaders/ImageLoader.load)
```
.load ( url : String, onLoad : Function, onProgress : Function, onError : Function ) 
```
and this commit changes `src/datasources/base.js` to follow that signature.