### PR TITLE
add quadkey support for datasources

### DIFF
--- a/src/datasources/base.js
+++ b/src/datasources/base.js
@@ -80,9 +80,12 @@ class BaseDatasource {
     }
   }
 
-  urlForTile( x, y, z ) {
+  urlForTile( quadkey ) {
+    const [x, y, z] = tilebelt.quadkeyToTile( quadkey );
+    
     return this.urlFormat.replace( '{x}', x ).replace( '{y}', y )
-      .replace( '{z}', z ).replace( '{apiKey}', this.apiKey );
+      .replace( '{z}', z ).replace('{quadkey}', quadkey)
+      .replace( '{apiKey}', this.apiKey );
   }
 
   fetchIfNeeded( quadkey ) {
@@ -105,7 +108,7 @@ class BaseDatasource {
     this.fetching[ quadkey ] = newIndex;
 
     // Actually fetch data
-    let url = this.urlForTile( ...tilebelt.quadkeyToTile( quadkey ) );
+    let url = this.urlForTile( quadkey );
     ImageLoader.load( url, ( image ) => {
       // Image loaded OK
         this.imgCache[ quadkey ] = image;


### PR DESCRIPTION
#### Problem
most tile sources use x/y/z tile url format but there are a few (most notably Bing) which use quadkey for their tile urls

#### Solution
this very simple pull request adds `{quadkey}` parameter for tile urls